### PR TITLE
Add xcc3641/minimax-h3-starter to Prompting

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,6 @@ Community workflows:
 * [`joeygambino/MiniMax-H3-Multishot-Workflow`](https://huggingface.co/joeygambino/MiniMax-H3-Multishot-Workflow) — Strings several FL2VA/Ref2VA clips into one continuous sequence with matched audio handoffs. Apache-2.0 licensed.
 * [`javawock7618/comfy-MiniMax-H3-workflows`](https://huggingface.co/javawock7618/comfy-MiniMax-H3-workflows) — Bundles the entire low-VRAM acceleration stack into one importable workflow.
 * [OrbitQuant T2VA](https://huggingface.co/WaveCut/MiniMax-H3-OrbitQuant-W4A4/resolve/main/comfyui/workflows/MiniMax-H3-OrbitQuant-T2VA.json) · [T2VA API form](https://huggingface.co/WaveCut/MiniMax-H3-OrbitQuant-W4A4/resolve/main/comfyui/workflows/MiniMax-H3-OrbitQuant-T2VA-api.json) · [Ref2VA API form](https://huggingface.co/WaveCut/MiniMax-H3-OrbitQuant-W4A4/resolve/main/comfyui/workflows/MiniMax-H3-OrbitQuant-Ref2VA-api.json) — require [`ComfyUI-OrbitQuant`](https://github.com/WaveCut/ComfyUI-OrbitQuant).
-* [`xcc3641/minimax-h3-starter`](https://github.com/xcc3641/minimax-h3-starter) — Beginner T2V and I2V ComfyUI graphs, plus the finished clips and prompt revisions they were used for. Depends on [`ComfyUI-MiniMaxH3-Easy`](https://github.com/nkxx188/ComfyUI-MiniMaxH3-Easy).
 
 <a id="recipes-prompt"></a>
 

--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ Community workflows:
 * [`joeygambino/MiniMax-H3-Multishot-Workflow`](https://huggingface.co/joeygambino/MiniMax-H3-Multishot-Workflow) — Strings several FL2VA/Ref2VA clips into one continuous sequence with matched audio handoffs. Apache-2.0 licensed.
 * [`javawock7618/comfy-MiniMax-H3-workflows`](https://huggingface.co/javawock7618/comfy-MiniMax-H3-workflows) — Bundles the entire low-VRAM acceleration stack into one importable workflow.
 * [OrbitQuant T2VA](https://huggingface.co/WaveCut/MiniMax-H3-OrbitQuant-W4A4/resolve/main/comfyui/workflows/MiniMax-H3-OrbitQuant-T2VA.json) · [T2VA API form](https://huggingface.co/WaveCut/MiniMax-H3-OrbitQuant-W4A4/resolve/main/comfyui/workflows/MiniMax-H3-OrbitQuant-T2VA-api.json) · [Ref2VA API form](https://huggingface.co/WaveCut/MiniMax-H3-OrbitQuant-W4A4/resolve/main/comfyui/workflows/MiniMax-H3-OrbitQuant-Ref2VA-api.json) — require [`ComfyUI-OrbitQuant`](https://github.com/WaveCut/ComfyUI-OrbitQuant).
+* [`xcc3641/minimax-h3-starter`](https://github.com/xcc3641/minimax-h3-starter) — Beginner T2V and I2V ComfyUI graphs, plus the finished clips and prompt revisions they were used for. Depends on [`ComfyUI-MiniMaxH3-Easy`](https://github.com/nkxx188/ComfyUI-MiniMaxH3-Easy).
 
 <a id="recipes-prompt"></a>
 
@@ -419,6 +420,7 @@ H3 prompts have a fixed three-part structure, inline `<Picture X>` / `<Video X>`
 | [`comfyui-minimax-h3-prompt-enhancer-T8`](https://github.com/T8mars/comfyui-minimax-h3-prompt-enhancer-T8) | Provides server-side prompt enhancement via `doubao-seed-evolving`. |
 | [`awesome-minimax-h3-prompts`](https://github.com/BeatAPI/awesome-minimax-h3-prompts) | A prompt corpus with WebM examples and author attribution, categorized into story, action/fantasy, ad/product, music performance, and vlog. |
 | [`minimax-h3-prompt-skill-T8`](https://github.com/T8mars/minimax-h3-prompt-skill-T8) | "Creative DNA" case library, installable as an agent skill, with an Electron desktop viewer. |
+| [`xcc3641/minimax-h3-starter`](https://github.com/xcc3641/minimax-h3-starter) | Beginner lab: T2V/I2V case studies with full prompt revision history, a portable `SKILL.md` for T2VA / I2VA / FL2VA / L2VA / Ref2VA, and a stdlib CLI that regenerates a finished 768p clip to 2K. |
 
 If you run H3 from a coding agent instead of the ComfyUI canvas, see: [`Minimax-H3-Prompt-AgentSkill`](https://github.com/benjiyaya/Minimax-H3-Prompt-AgentSkill) · [`minimax-h3-opencode-skills`](https://github.com/unknowlei/minimax-h3-opencode-skills) (director, routing, and multi-shot planning) · [`ComfyUI-Agent-Kit`](https://github.com/SlavaSexton/ComfyUI-Agent-Kit) (shared by Claude Code, Codex, Gemini CLI, and Qwen Code) · [`ComfyUI-PainterNodes`](https://github.com/princepainter/ComfyUI-PainterNodes) (`MiniMaxRefToVideo2`, with the official reference and dialogue format).
 


### PR DESCRIPTION
Adds [`xcc3641/minimax-h3-starter`](https://github.com/xcc3641/minimax-h3-starter) under **Prompting** only.

It is a beginner lab: T2V/I2V case studies with full prompt revision history, plus a portable `SKILL.md` for T2VA / I2VA / FL2VA / L2VA / Ref2VA. Same shelf as `awesome-minimax-h3-prompts` and `minimax-h3-prompt-skill-T8`.
