### PR TITLE
Prompting: collect agent skills into their own section

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,20 @@ H3 prompts have a fixed three-part structure, inline `<Picture X>` / `<Video X>`
 | [`awesome-minimax-h3-prompts`](https://github.com/BeatAPI/awesome-minimax-h3-prompts) | A prompt corpus with WebM examples and author attribution, categorized into story, action/fantasy, ad/product, music performance, and vlog. |
 | [`minimax-h3-prompt-skill-T8`](https://github.com/T8mars/minimax-h3-prompt-skill-T8) | "Creative DNA" case library, installable as an agent skill, with an Electron desktop viewer. |
 
-If you run H3 from a coding agent instead of the ComfyUI canvas, see: [`Minimax-H3-Prompt-AgentSkill`](https://github.com/benjiyaya/Minimax-H3-Prompt-AgentSkill) · [`minimax-h3-opencode-skills`](https://github.com/unknowlei/minimax-h3-opencode-skills) (director, routing, and multi-shot planning) · [`ComfyUI-Agent-Kit`](https://github.com/SlavaSexton/ComfyUI-Agent-Kit) (shared by Claude Code, Codex, Gemini CLI, and Qwen Code) · [`ComfyUI-PainterNodes`](https://github.com/princepainter/ComfyUI-PainterNodes) (`MiniMaxRefToVideo2`, with the official reference and dialogue format).
+<a id="agent-skills"></a>
+
+### Agent skills
+
+Skill packages that let a coding agent drive H3 without the ComfyUI canvas. They differ in how far they take you, and are listed here from the most complete: one carries a brief through to a finished file, one drives a local ComfyUI, and the rest write the prompt and hand it back for you to run.
+
+| Skill repo | Runs against | What it does |
+| :--- | :--- | :--- |
+| [`awesome-minimax-h3`](https://github.com/joeVenner/awesome-minimax-h3) | Hosted API | Carries a brief through to a finished file against the hosted MiniMax API: submit, poll with backoff, resolve the returned `file_id`, then post-process with `ffmpeg`. Reports that the documented `/v2/…/query` polling form returns 404 and gives `GET /v1/query/video_generation` as the working call. Three `SKILL.md` packages — `minimax-video` for H3, plus Speech 2.8 and Music 3.0 skills that compose with it. Needs a `MINIMAX_API_KEY`, not local weights. MIT. |
+| [`ComfyUI-Agent-Kit`](https://github.com/SlavaSexton/ComfyUI-Agent-Kit) | Local ComfyUI | Drives a local ComfyUI end to end from Claude Code, Codex, Gemini CLI, or Qwen Code — workflow building, hardware-aware model selection, multi-shot video. Ships a standalone H3 skill among its 581 templates. Apache-2.0. |
+| [`Minimax-H3-Prompt-AgentSkill`](https://github.com/benjiyaya/Minimax-H3-Prompt-AgentSkill) | Prompt only | Builds a formatted H3 prompt from your media and idea, then hands it back for you to run. No license stated. |
+| [`minimax-h3-opencode-skills`](https://github.com/unknowlei/minimax-h3-opencode-skills) | Prompt only | OpenCode skill suite covering directing, routing, multi-shot planning, prompt generation, and review. MIT. |
+
+Also relevant: [`ComfyUI-PainterNodes`](https://github.com/princepainter/ComfyUI-PainterNodes) (`MiniMaxRefToVideo2`, with the official reference and dialogue format), and [`minimax-h3-prompt-skill-T8`](https://github.com/T8mars/minimax-h3-prompt-skill-T8) in the table above, which ships its case library as an installable skill.
 
 <a id="speed"></a>
 


### PR DESCRIPTION
Agent-skill repos are currently spread across two places — one row in the prompt table (`minimax-h3-prompt-skill-T8`) and a trailing sentence listing four more. That made it hard to see what each one actually does for you, since they range from "writes a prompt and hands it back" to "produces a finished file."

This groups them under a new **Agent skills** subsection (anchor `#agent-skills`) with a **Runs against** column, which is the real difference between them.

**On ordering:** the rows run by how much of the pipeline each one covers, most complete first — hosted API → local ComfyUI → prompt-only. That is deliberately not a popularity order, and I want to flag it rather than have you discover it: my own entry is the newest and smallest of the four, and it sits first only because it covers the most of the pipeline. The existing prompt table already orders on something other than stars (`minimax-h3-prompt-skill-T8` is the most-starred entry in this section and sits last), so there's precedent — but if you'd rather this table ran by developer interest like the rest of the index, say so and I'll flip it. My entry goes last under that rule and that's completely fine by me.

**Added:** [`joeVenner/awesome-minimax-h3`](https://github.com/joeVenner/awesome-minimax-h3) — MIT, plain Markdown `SKILL.md` files with no runtime to install. Carries a brief through to a finished file against the hosted MiniMax API: submit, poll with backoff, resolve the returned `file_id`, post-process with `ffmpeg`. It reports that the documented `/v2/…/query` polling form returns 404 and gives `GET /v1/query/video_generation` as the working call.

Kept deliberately narrow:

- The prompt table is untouched, as is the `OpenH3-IR` double-listing (the page already explains that one is intentional).
- `ComfyUI-PainterNodes` and `minimax-h3-prompt-skill-T8` keep their cross-references in a trailing line, so nothing that was linked before is now unreachable.
- The new entry is flagged inline as needing a `MINIMAX_API_KEY` rather than local weights, since the rest of this index is local-first. It also ships Speech 2.8 and Music 3.0 skills; those are named in the cell but not given their own rows, as they're outside this index's scope.

Happy to reword, reorder, or drop my entry — and if you'd rather keep the flat sentence and just take the one addition, I can reduce this to a one-line diff instead.

Context: Ryan pointed me here by email, and Asuka asked me to submit a PR for review.